### PR TITLE
Make a dummy password check for non existing users

### DIFF
--- a/lib/passport/session_manager.ex
+++ b/lib/passport/session_manager.ex
@@ -16,7 +16,7 @@ defmodule Passport.SessionManager do
   end
 
   def authenticate(nil, _) do
-    false
+    Comeonin.Bcrypt.dummy_checkpw
   end
 
   def authenticate(user, password) do


### PR DESCRIPTION
"Perform a dummy check for a user that does not exist. This always returns false. The reason for implementing this check is in order to make user enumeration by timing responses more difficult."
See: http://hexdocs.pm/comeonin/Comeonin.Bcrypt.html#dummy_checkpw/0
